### PR TITLE
args::stdargv: skip first argument

### DIFF
--- a/args.um
+++ b/args.um
@@ -131,7 +131,7 @@ fn mk*(programName: str, programVer: str, programDesc: str, args: []str): Args {
         programName: programName, 
         programVer: programVer,
         programDesc: programDesc,
-        sourceArgs: slice(args, 1) // skip the program name
+        sourceArgs: args
     }
 }
 
@@ -464,9 +464,9 @@ fn (args: ^Args) usage*() {
 // Returns the command line arguments.
 fn stdargv*(): []str {
 //~~
-    list := make([]str, std::argc())
+    list := make([]str, std::argc()-1)
 
-    for i := 0; i < std::argc(); i++ {
+    for i := 1; i < std::argc(); i++ {
         list[i] = std::argv(i)
     }
 


### PR DESCRIPTION
`args::stdargv` gets changed to skip the first argument, so that `args::mk` doesn't have to strip it off

this PR is due to the fact that the user may have also processed the arguments a bit already and had just passed the ones that they do care about, and because `stdargv` doesn't need to return the program name if it's already passed to the parser

if the parser really needed to know how was the program called through, it would just get passed `std::argv(0)` to the `programName` parameter from the get-go
